### PR TITLE
Update package.json for react-native-svg-macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.1.0",
-  "name": "react-native-svg",
+  "version": "0.1.0",
+  "name": "react-native-svg-macos",
   "description": "SVG library for react-native",
-  "homepage": "https://github.com/react-native-community/react-native-svg",
+  "homepage": "https://github.com/microsoft/react-native-svg-macos",
   "repository": {
     "type": "git",
-    "url": "https://github.com/react-native-community/react-native-svg"
+    "url": "https://github.com/microsoft/react-native-svg-macos"
   },
   "license": "MIT",
   "main": "lib/commonjs/index.js",
@@ -34,6 +34,7 @@
     "react-component",
     "react-native",
     "ios",
+    "macos",
     "android",
     "SVG",
     "ART",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "12.1.0",
   "name": "react-native-svg-macos",
   "description": "SVG library for react-native",
   "homepage": "https://github.com/microsoft/react-native-svg-macos",


### PR DESCRIPTION
This updates package.json to prepare this for packaging.

I've chosen to set the version number of this to 0.1.0 because it more emphasizes the newness of the macOS portion, although I'm open to changing this value to something else if anyone else has any opinions otherwise.